### PR TITLE
Add Lato font import from Google Fonts

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap');
+
 body {
     background-color: #1a1a20;
     font-family: Lato, Arial, Helvetica, sans-serif;


### PR DESCRIPTION
Since Lato wasn't imported, and most computers don't have Lato preinstalled by default, it doesn't show the font on the index page. I've imported it through Google Fonts.