### PR TITLE
Bug fix comma

### DIFF
--- a/studio/index.html
+++ b/studio/index.html
@@ -109,8 +109,9 @@
         <br>
         <p>Select comma type:</p>
         <select name="selectcomma" id="selectcomma">
-            <option value="comma1">,ddd</option>
-            <option value="comma2"> ddd</option>
+            <option value="comma1">,ddd (1,234,567)</option>
+            <option value="comma2">.ddd (1.234.567)</option>
+            <option value="comma3"> ddd (1 234 567)</option>
         </select>
         <br>
         <br>


### PR DESCRIPTION
Summary of Changes for Odometer Thousands Separator Formatting:

1. HTML (index.html) Changes:
    *   Updated the HTML for the `<select id="selectcomma">` element.
    *   Options within the dropdown now include visual examples of the format for better user clarity (e.g., ",ddd (1,234,567)").

2. JavaScript (script.js) Changes & Fixes:

    *   Added:
        *   Introduced the `format` option to `window.odometerOptions` (defaulting to `'(,ddd)'`).
        *   Added a `commaFormat` property to the `user` object to store the user's selected separator format (defaults to `'(,ddd)'`).
        *   Implemented logic to initialize `user.commaFormat` and `window.odometerOptions.format` when loading user data from `localStorage` or creating a new user (for backward compatibility and correct operation).
        *   Created the `applyCommaFormatAndUpdate()` function, which:
            *   Retrieves the selected value from `#selectcomma`.
            *   Sets the appropriate format (`(,ddd)`, `(.ddd)`, `( ddd)`) for `window.odometerOptions.format` and `user.commaFormat`.
            *   **Fixed:** Directly updates the `format` option of the existing Odometer instance (`countElement.odometer.options.format = newFormat;`).
            *   **Fixed:** Calls `countElement.odometer.update(user.count)` to immediately re-render the odometer with the new format without a page reload.
        *   Added a `change` event listener to `#selectcomma` that calls `applyCommaFormatAndUpdate()`.
        *   Implemented logic to set the initial value of `#selectcomma` based on the stored `user.commaFormat`.
        *   Updated `importData()` and `selectThing()` functions to support and persist `commaFormat` during data import/export.

    *   Fixed:
        *   Addressed potential variable name conflicts in the `pickChannel` and `selectThing` functions.
        *   Improved image update logic in `submit()`: `document.getElementById('image').src` is now updated within the `reader.onload` callback for `file_input`.
        *   Added `.trim()` when parsing dates in `submit2()` to prevent issues with leading/trailing spaces.
        *   Ensured correct updating of the odometer's DOM element in the `render()` function.
        *   Made minor reliability improvements for initializing and loading saved format settings.